### PR TITLE
SMDegrain: fix broken BFF interlace handling

### DIFF
--- a/SMDegrain/SMDegrain.avsi
+++ b/SMDegrain/SMDegrain.avsi
@@ -1346,7 +1346,7 @@ function SMD_UnfoldFieldsVertical(clip c, bool "flip", bool "TFF") {
 
     flip   = Default(flip, false)
     TFF    = Default(TFF,   true)
-    c      = c.AssumeTFF().SeparateFields()
+    c      = (TFF ? c.AssumeTFF() : c.AssumeBFF()).SeparateFields()
     top    = c.SelectEven()
     bottom = c.SelectOdd()
     StackVertical(top, flip ? bottom.FlipVertical()


### PR DESCRIPTION
The SMD_UnfoldFieldsVertical function takes a TFF parameter, but doesn't actually use it when assigning the parity of the input clip.  This results in horribly destroyed results when using BFF interlaced clips.

Fix this by using TFF to determine whether to call AssumeTFF or AssumeBFF.

Here's an example that shows the problem.  The input image originated from a DV camcorder that interlaced using BFF.  I used the filter `SMDegrain(interlaced=true)` to generate the outputs.

I git bisected the repository and found this regression was first introduced in e3cea8f54132f19e6e3aeff6ad66e899cdb9ad1c

**Original input image**
![image](https://github.com/user-attachments/assets/1b35ef25-6551-4d62-ba41-aeffa045327f)

**Broken interlace handling seen in master**
![image](https://github.com/user-attachments/assets/e3881276-74d9-4b25-8f36-c79f03365186)

**Results after applying this commit**
![image](https://github.com/user-attachments/assets/73e7a7c7-e897-4c4f-9b98-7450ac37c3d8)
